### PR TITLE
Chapter 6 - bug fix: clicking the wrong card

### DIFF
--- a/Royale/Pages/CardsPage.cs
+++ b/Royale/Pages/CardsPage.cs
@@ -30,6 +30,6 @@ namespace Royale.Pages
 
     public class CardsPageMap
     {
-        public IWebElement Card(string name) => Driver.FindElement(By.CssSelector($"a[href*='{name}']"));
+        public IWebElement Card(string name) => Driver.FindElement(By.CssSelector($"a[href$='/{name}']"));
     }
 }


### PR DESCRIPTION
Cards whose entire names (like "Zap" or "Knight") are a fraction of another card's name ("Zappies" or "Mega Knight") were not getting navigated to because those other cards steal the navigation.