### PR TITLE
Add new Tests - Tournament, Top Lists, Decks

### DIFF
--- a/Royale.Tests/DecksTests.cs
+++ b/Royale.Tests/DecksTests.cs
@@ -1,0 +1,32 @@
+using Framework.Selenium;
+using NUnit.Framework;
+using Royale.Pages;
+
+namespace Tests
+{
+    public class DecksTest : TestBase
+    {
+        HeaderNav headerNav = new HeaderNav();
+
+        [Test, Category("decks")]
+        public void Can_navigate_to_popular_decks_page()
+        {
+            headerNav.ClickDecksDropdown().ClickPopularDecksLink();
+            Assert.That(Driver.Title, Is.EqualTo("Best Clash Royale Decks"));
+        }
+
+        [Test, Category("decks")]
+        public void Can_navigate_to_challenge_decks_page()
+        {
+            headerNav.ClickDecksDropdown().ClickChallengeDecksLink();
+            Assert.That(Driver.Title, Is.EqualTo("Recent Winners - Clash Royale"));
+        }
+
+        [Test, Category("decks")]
+        public void Can_navigate_to_top_player_decks_page()
+        {
+            headerNav.ClickDecksDropdown().ClickTopPlayerDecksLink();
+            Assert.That(Driver.Title, Is.EqualTo("Top Players - Clash Royale"));
+        }
+    }
+}

--- a/Royale.Tests/TopListsTests.cs
+++ b/Royale.Tests/TopListsTests.cs
@@ -1,0 +1,32 @@
+using Framework.Selenium;
+using NUnit.Framework;
+using Royale.Pages;
+
+namespace Tests
+{
+    public class TopListsTests : TestBase
+    {
+        HeaderNav headerNav = new HeaderNav();
+
+        [Test, Category("toplists")]
+        public void Can_navigate_to_popular_cards_page()
+        {
+            headerNav.ClickTopListsDropdown().ClickPopularCardsLink();
+            Assert.That(Driver.Title, Is.EqualTo("Top Clash Royale Cards"));
+        }
+
+        [Test, Category("toplists")]
+        public void Can_navigate_to_top_players_page()
+        {
+            headerNav.ClickTopListsDropdown().ClickTopPlayersLink();
+            Assert.That(Driver.Title, Is.EqualTo("StatsRoyale.com - Clash Royale Statistics"));
+        }
+
+        [Test, Category("toplists")]
+        public void Can_navigate_to_top_clans_page()
+        {
+            headerNav.ClickTopListsDropdown().ClickTopClansLink();
+            Assert.That(Driver.Title, Is.EqualTo("Top Clans"));
+        }
+    }
+}

--- a/Royale.Tests/TournamentsTests.cs
+++ b/Royale.Tests/TournamentsTests.cs
@@ -6,18 +6,18 @@ namespace Tests
 {
     public class TournamentsTests : TestBase
     {
+        HeaderNav headerNav = new HeaderNav();
+
         [Test, Category("tournaments")]
-        public void Leagues_page_loads()
+        public void Can_navigate_to_Leagues_page()
         {
-            var headerNav = new HeaderNav();
             headerNav.ClickTournamentsDropdown().ClickLeaguesLink();
             Assert.That(Driver.Title, Is.EqualTo("Leagues"));
         }
 
         [Test, Category("tournaments")]
-        public void Free_Tournaments_page_loads()
+        public void Can_navigate_to_Free_Tournaments_page()
         {
-            var headerNav = new HeaderNav();
             headerNav.ClickTournamentsDropdown().ClickFreeTournamentsLink();
             Assert.That(Driver.Title, Is.EqualTo("StatsRoyale.com - Clash Royale Statistics")); 
         }

--- a/Royale/Pages/HeaderNav.cs
+++ b/Royale/Pages/HeaderNav.cs
@@ -34,15 +34,49 @@ namespace Royale.Pages
             Map.TournamentsTabDropdown.Click();
             return this;
         }
-
         public void ClickLeaguesLink()
         {
             ClickDropdownOption(Map.LeaguesDropdownLink);
         }
-
         public void ClickFreeTournamentsLink()
         {
             ClickDropdownOption(Map.FreeTournamentsDropdownLink);
+        }
+
+        public HeaderNav ClickTopListsDropdown()
+        {
+            Map.TopListsTabDropdown.Click();
+            return this;
+        }
+        public void ClickPopularCardsLink()
+        {
+            ClickDropdownOption(Map.PopularCardsDropdownLink);
+        }
+        public void ClickTopPlayersLink()
+        {
+            ClickDropdownOption(Map.TopPlayersDropdownLink);
+        }
+        public void ClickTopClansLink()
+        {
+            ClickDropdownOption(Map.TopClansDropdownLink);
+        }
+
+        public HeaderNav ClickDecksDropdown()
+        {
+            Map.DecksTabDropdown.Click();
+            return this;
+        }
+        public void ClickPopularDecksLink()
+        {
+            ClickDropdownOption(Map.PopularDecksDropdownLink);
+        }
+        public void ClickChallengeDecksLink()
+        {
+            ClickDropdownOption(Map.ChallengeDecksDropdownLink);
+        }
+        public void ClickTopPlayerDecksLink()
+        {
+            ClickDropdownOption(Map.TopPlayerDecksDropdownLink);
         }
 
         private void ClickDropdownOption(Element element)
@@ -61,11 +95,25 @@ namespace Royale.Pages
 
     public class HeaderNavMap
     {
+        //Tournaments
         public Element TournamentsTabDropdown => Driver.FindElement(By.XPath("//a[contains(@class,'linkWithDropdown') and contains(text(),'Tournaments')]"), "Tournaments Dropdown");
         public Element LeaguesDropdownLink => Driver.FindElement(By.CssSelector("a[href='/leagues']"), "Leagues Dropdown Link");
         public Element FreeTournamentsDropdownLink => Driver.FindElement(By.CssSelector("a[href='/tournaments']"), "Leagues Dropdown Link");
 
+        //Cards and Deck Builder
         public Element CardsTabLink => Driver.FindElement(By.CssSelector("a[href='/cards']"), "Cards Link");
         public Element DeckBuilderTabLink => Driver.FindElement(By.CssSelector("a[href*='/deckbuilder']"), "Deck Builder Link");
+
+        //Top Lists
+        public Element TopListsTabDropdown => Driver.FindElement(By.XPath("//a[contains(@class,'linkWithDropdown') and contains(text(),'Top Lists')]"), "Tops Lists Dropdown");
+        public Element PopularCardsDropdownLink => Driver.FindElement(By.CssSelector("a[href='/top/cards']"), "Popular Cards Dropdown Link");
+        public Element TopPlayersDropdownLink => Driver.FindElement(By.CssSelector("a[href='/top/players']"), "Top Players Dropdown Link");
+        public Element TopClansDropdownLink => Driver.FindElement(By.CssSelector("a[href='/top/clans']"), "Top Clans Dropdown Link");
+
+        //Decks
+        public Element DecksTabDropdown => Driver.FindElement(By.XPath("//a[contains(@class,'linkWithDropdown') and contains(text(),'Decks')]"), "Decks Dropdown");
+        public Element PopularDecksDropdownLink => Driver.FindElement(By.CssSelector("a[href='/decks/popular']"), "Popular Decks Dropdown Link");
+        public Element ChallengeDecksDropdownLink => Driver.FindElement(By.CssSelector("a[href*='/decks/challenge']"), "Challenge Deck Dropdown Link");
+        public Element TopPlayerDecksDropdownLink => Driver.FindElement(By.CssSelector("a[href*='/decks/top200']"), "Top Player Decks Dropdown Link");
     }
 }


### PR DESCRIPTION
These new sets of tests click on the different dropdowns and verify that each of the dropdown option pages load
The bulk of the code was added into the HeaderNav instead of creating new pages because these things should be accessible from any page.
I organized them into 3 test classes to help make them scalable. Right now, these tests basically do the same thing. However, if further testing is required on the pages we navigate to, then it's better that the 3 different HeaderNav dropdown options remain in their own test classes.
It was interesting to consider what else to test on this site, as much of the data on these pages I navigate to changes frequently. 